### PR TITLE
a new file sysMongodb.py to operate local MongoDB

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,8 @@ sleep 5
 
 echo "\nConfiguring the MongoDB ReplicaSet...\n"
 # 5.0 and above we can use mongosh else we use the oild mongo shell
-docker-compose exec mongo1 ${MDBSHELL} --eval '''rsconf = { _id : "rs0", members: [ { _id : 0, host : "mongo1:27017", priority: 1.0 }]}; rs.initiate(rsconf);'''
+# host : "localhost:27017". Use localhost for the replica set configuration that are accessible by the host so that pymongo have access
+docker-compose exec mongo1 ${MDBSHELL} --eval '''rsconf = { _id : "rs0", members: [ { _id : 0, host : "localhost:27017", priority: 1.0 }]}; rs.initiate(rsconf);'''
 
 echo '''
 ==============================================================================================================

--- a/sysModule.py
+++ b/sysModule.py
@@ -13,12 +13,13 @@ load_dotenv()
 
 # Access environment variables
 VM_IP = os.getenv("VM_IP")
-mongodb_conn_url = os.getenv("mongodb_conn_url")
-mongodb_database = os.getenv("mongodb_database")
-mongodb_collection = os.getenv("mongodb_collection")
+sys_id = os.getenv("sys_id")
+mongodb_remote_conn_url = os.getenv("mongodb_remote_conn_url")
+mongodb_remote_database = os.getenv("mongodb_remote_database")
+mongodb_remote_collection = os.getenv("mongodb_remote_collection")
 
 class sysModule:
-    def __init__(self, id:str, lst_servers:list):
+    def __init__(self, lst_servers:list, id=sys_id):
         self.id = id
         self.lst_servers = lst_servers
         self.lst_mqtt_topics = self.init_lst_mqtt_topics()
@@ -74,9 +75,9 @@ class sysModule:
                             "connector.class":"com.mongodb.kafka.connect.MongoSinkConnector",
                             "tasks.max":1,
                             "topics": self.id,
-                            "connection.uri":mongodb_conn_url,
-                            "database":mongodb_database,
-                            "collection":mongodb_collection,
+                            "connection.uri":mongodb_remote_conn_url,
+                            "database":mongodb_remote_database,
+                            "collection":mongodb_remote_collection,
                             "key.converter":"org.apache.kafka.connect.storage.StringConverter",
                             "value.converter":"org.apache.kafka.connect.json.JsonConverter",
                             "value.converter.schemas.enable":"false",

--- a/sysMongodb.py
+++ b/sysMongodb.py
@@ -1,0 +1,23 @@
+import asyncio
+import motor.motor_asyncio
+
+# Connect to MongoDB
+client = motor.motor_asyncio.AsyncIOMotorClient('mongodb://localhost:27017')
+db = client['mydatabase']
+collection = db['mycollection']
+
+async def main():
+    # Insert a document
+    document = {'name': 'John Doe', 'age': 30}
+    await collection.insert_one(document)
+
+    # Find documents
+    async for result in collection.find({'age': {'$gt': 25}}):
+        print(result)
+
+    # Close the connection
+    await client.close()
+    # TODO: #12 TypeError: object NoneType can't be used in 'await' expression
+
+# Run the event loop
+asyncio.run(main())


### PR DESCRIPTION
Fixes #11
1. modify the mongodb replica set to use localhost:27017 as the host
2. get sysMongodb.py up and run the script
3. revise the .env file